### PR TITLE
Add caching for Go tests and builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,36 @@
-# This is a multi-stage Dockerfile. The first part executes a build in a Golang
-# container, and the second retrieves the binary from the build container and
+# This is a multi-stage Dockerfile.
+# The first part retrieves Go dependencies, the second compiles the binary in
+# a Go container, and the second retrieves the binary from the build container and
 # inserts it into a "scratch" image.
+# An additional image is included for executing tests.
 
-# Part 1: Execute the tests in a containerized Golang environment
+# Part 1: Create a layer for Go module dependencies
 #
-FROM golang:1.16 as test
+FROM golang:1.16 as gomodules
+
+WORKDIR /gort
+COPY go.mod go.sum /gort/
+RUN go mod download
+
+# Part 1a: Execute the tests in a containerized Golang environment
+#
+FROM gomodules as test
+
+WORKDIR /gort
+COPY . /gort
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  go test -v ./...
+
+# Part 3: Compile the binary in a containerized Golang environment
+#
+FROM gomodules as builder
 
 COPY . /gort
 WORKDIR /gort
-RUN go test -v ./...
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  GOOS=linux go build -a -installsuffix cgo -o gort .
 
-# Part 2: Compile the binary in a containerized Golang environment
-#
-FROM golang:1.16 as builder
-
-COPY . /gort
-WORKDIR /gort
-RUN GOOS=linux go build -a -installsuffix cgo -o gort .
-
-# Part 3: Build the Gort image proper
+# Part 4: Build the Gort image proper
 #
 FROM ubuntu:20.04 as image
 
@@ -26,8 +38,8 @@ FROM ubuntu:20.04 as image
 #
 RUN apt update                                              \
   && apt-get -y --force-yes install --no-install-recommends \
-    ssh                                                     \
-    ca-certificates                                         \
+  ssh                                                     \
+  ca-certificates                                         \
   && apt-get clean                                          \
   && apt-get autoclean                                      \
   && apt-get autoremove                                     \

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test_begin:
 	@docker run -d -e POSTGRES_USER=gort -e POSTGRES_PASSWORD=password -p 5432:5432 --name foo_postgres postgres:13
 
 test: test_begin
-	@docker build --target test -t foo_$(PROJECT)_foo --network host .
+	@DOCKER_BUILDKIT=1 docker build --target test -t foo_$(PROJECT)_foo --network host .
 	@docker rmi foo_$(PROJECT)_foo
 	@docker stop foo_postgres
 	@docker rm foo_postgres
@@ -50,7 +50,7 @@ build: clean
 	@go build -a -installsuffix cgo -o bin/$(PROJECT) $(GIT_REPOSITORY)
 
 image: test_begin
-	@docker build --target image -t $(IMAGE_NAME):$(IMAGE_TAG) --network host .
+	@DOCKER_BUILDKIT=1 docker build --target image -t $(IMAGE_NAME):$(IMAGE_TAG) --network host .
 	@docker stop foo_postgres
 	@docker rm foo_postgres
 


### PR DESCRIPTION
This change adds two type of caching to the Dockerfile:
- A separate layer for go modules so they only need downloading if
  go.mod/go.sum change.
- A cache mount when building or testing the go source to take advantage
  of Go's built-in caching.

With a warm cache, this brought the time to execute `make test` down
from 1m28s to ~15s on a 2017 Macbook Pro (3.5 GHz Dual-Core Intel Core
i7, 16GB RAM).

To ensure the cache mount is used (Docker Engine 19+), DOCKER_BUILDKIT
is set for calls to `docker build`.